### PR TITLE
Remove the EPUB output.

### DIFF
--- a/manual/index.rst
+++ b/manual/index.rst
@@ -2,7 +2,7 @@
 
 .. only:: builder_html
 
-   In addition to the HTML you are currently viewing, the |title| manual is also available in `PDF <mastering-eos.pdf>`_, `EPUB (e-book) <mastering-eos.epub>`_, and HTML archive (`.tar.gz <mastering-eos-html.tar.gz>`_ or `.zip <mastering-eos-html.zip>`_) formats, or by typing ``man eos`` or ``info eos`` on any EOS or Arch machine.
+   In addition to the HTML you are currently viewing, the |title| manual is also available in `PDF <mastering-eos.pdf>`_ and HTML archive (`.tar.gz <mastering-eos-html.tar.gz>`_ or `.zip <mastering-eos-html.zip>`_) formats, or by typing ``man eos`` or ``info eos`` on any EOS or Arch machine.
 
    .. The poster is visible in the Architecture Lab and is also available `as a PDF <mastering-eos-poster.pdf>`_.
 

--- a/manual/wscript
+++ b/manual/wscript
@@ -85,7 +85,7 @@ def build(ctx):
         ])
 
     ctx(features='sphinx',
-        builders='latexpdf html epub man info',
+        builders='latexpdf html man info',
         source='conf.py',
         # Turn warnings into errors. Helps them get fixed more quickly :)
         warningiserror=True,

--- a/wscript
+++ b/wscript
@@ -107,15 +107,11 @@ def archive(ctx):
             source=node,
             target=website_dir.find_or_declare(node.path_from(html_build_dir)))
 
-    # Copy PDF and EPUB.
+    # Copy PDF.
     ctx(rule=_copy_file,
         source=ctx.bldnode.find_node([
             'manual', 'latexpdf', 'mastering-eos.pdf']),
         target=website_dir.find_or_declare('mastering-eos.pdf'))
-    ctx(rule=_copy_file,
-        source=ctx.bldnode.find_node([
-            'manual', 'epub', 'mastering-eos.epub']),
-        target=website_dir.find_or_declare('mastering-eos.epub'))
 
     # Copy poster.
     ctx(rule=_copy_file,


### PR DESCRIPTION
Rationale:
- The Sphinx EPUB builder is broken in at least two ways (mime type
  issue and search index issue). While the sources of these problems
  have been identified, worked around in our Waf-Sphinx tool, and could
  be fixed in Sphinx, EPUB does not in general seem to be well-supported
  in Sphinx.
- Our EPUB output at present looks pretty bad. We have not been checking
  it with diligence, and the format is not well-suited to technical
  documentation with frequent tables and code blocks.

The EPUB output is cool but nothing else. It's not useful, professional, practical, or time-efficient.
